### PR TITLE
feat: enable buildFeatures.buildConfig for android gradle plugin 8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,9 @@ android {
   def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
   if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
     namespace "com.braze.reactbridge"
+    buildFeatures {
+        buildConfig true
+    }
   }
 
   defaultConfig {


### PR DESCRIPTION
This change is required for AGP 8 included in RN 0.73.

More details here: https://github.com/th3rdwave/react-native-safe-area-context/pull/455