### PR TITLE
feat: support 0.73 by removing compileOptions, kotlinOptions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,16 +39,6 @@ android {
       }
     }
   }
-
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
-
-  kotlinOptions {
-    freeCompilerArgs = ['-Xjvm-default=all']
-    jvmTarget = "11"
-  }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,14 +40,8 @@ android {
     }
   }
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
-
   kotlinOptions {
     freeCompilerArgs = ['-Xjvm-default=all']
-    jvmTarget = "11"
   }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,16 @@ android {
       }
     }
   }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
+  }
+
+  kotlinOptions {
+    freeCompilerArgs = ['-Xjvm-default=all']
+    jvmTarget = "11"
+  }
 }
 
 dependencies {


### PR DESCRIPTION
Support RN 0.73 Android Native Build

reopened PR from https://github.com/braze-inc/braze-react-native-sdk/pull/241
