### PR TITLE
Add `ContentCardTypes` to `index.d.ts`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -855,6 +855,13 @@ interface GenderTypes {
 }
 export const Genders: GenderTypes;
 
+interface BrazeContentCardTypes {
+  CLASSIC: 'Classic';
+  IMAGE_ONLY: 'ImageOnly';
+  CAPTIONED: 'Captioned';
+}
+export const ContentCardTypes: BrazeContentCardTypes;
+
 interface NotificationSubscriptionType {
   OPTED_IN: 'optedin';
   SUBSCRIBED: 'subscribed';


### PR DESCRIPTION
Add `ContentCardTypes` to `index.d.ts`

Other types in [enums.js](https://github.com/braze-inc/braze-react-native-sdk/blob/master/src/models/enums.js) are exported to `index.d.ts` but `ContentCardTypes` is not exported yet.