### PR TITLE
Fix `duplicate symbol '_hasListeners'`

### DIFF
--- a/iOS/BrazeReactBridge/BrazeReactBridge/BrazeReactBridge.mm
+++ b/iOS/BrazeReactBridge/BrazeReactBridge/BrazeReactBridge.mm
@@ -32,7 +32,7 @@ static BrazeUIHandler *brazeUIHandler;
 
 @implementation BrazeReactBridge
 
-BOOL hasListeners = NO;
+static BOOL hasListeners = NO;
 
 #pragma mark - Setup
 


### PR DESCRIPTION
```
duplicate symbol '_hasListeners' in:
    /xxx/Library/Developer/Xcode/DerivedData/xxx-enqorveqxgntgycjpwyqvxjjinmq/Build/Products/Debug-iphoneos/braze-react-native-sdk/libbraze-react-native-sdk.a(BrazeReactBridge.o)
    /xxx/Library/Developer/Xcode/DerivedData/xxx-enqorveqxgntgycjpwyqvxjjinmq/Build/Products/Debug-iphoneos/quadpay-merchant-sdk-react-native/libquadpay-merchant-sdk-react-native.a(QuadPayBridge.o)
ld: 1 duplicate symbol for architecture arm64
```

* https://stackoverflow.com/questions/71500066/duplicate-symbol-haslisteners-react-native
* https://github.com/callstack/react-native-socket-mobile/issues/3
* https://github.com/innoveit/react-native-ble-manager/pull/1029

Created a pull request on the QuadPay side too.
https://github.com/quadpay/quadpay-merchant-sdk-react-native/pull/15