### PR TITLE
Change 'timestamp' for 'datetime' on TimestampFeatureFlagProperty

### DIFF
--- a/BrazeProject/BrazeProject.tsx
+++ b/BrazeProject/BrazeProject.tsx
@@ -881,7 +881,7 @@ export const BrazeProject = (): ReactElement => {
           featureFlagPropertyKey,
         );
         break;
-      case 'timestamp':
+      case 'datetime':
         property = await Braze.getFeatureFlagTimestampProperty(
           featureFlagId,
           featureFlagPropertyKey,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -976,7 +976,7 @@ export interface FeatureFlagBooleanProperty {
  */
 export interface FeatureFlagTimestampProperty {
   /** The type of Feature Flag property. */
-  type: "timestamp";
+  type: 'datetime';
 
   /** The value of the property. */
   value: number;


### PR DESCRIPTION
While the types in this SDK suggest that the FeatureFlagTimestampProperty's type field is a `timestamp`, the API returns `datetime` instead.

This is also how it is typed on the [Web SDK](https://js.appboycdn.com/web-sdk/6.1/doc/interfaces/braze.timestampproperty.html).

<img width="1261" height="558" alt="Screenshot 2025-09-19 at 17 17 00" src="https://github.com/user-attachments/assets/8e990dc3-b0e7-4845-92c7-8838091adf8a" />

Resolves #291